### PR TITLE
Optionally create parent directory in path utils.

### DIFF
--- a/utilities/path.py
+++ b/utilities/path.py
@@ -72,11 +72,11 @@ def current():
     return Path.cwd()
 
 
-def create(pathobj, directory=False, force=False):
+def create(pathobj, directory=False, force=False, parents=False):
     if directory:
         # pathobj.mkdir(exist_ok=force)  # does not work with Python 3.4...
         try:
-            pathobj.mkdir()
+            pathobj.mkdir(parents=parents)
         except FileExistsError:
             if force:
                 pass

--- a/utilities/processes.py
+++ b/utilities/processes.py
@@ -48,7 +48,7 @@ def wait_socket(host, port, service_name, sleep_time=1, timeout=5):
     import errno
     import socket
 
-    log.verbose("Waiting for %s" % service_name)
+    log.verbose("Waiting for %s (%s:%s)" % (service_name, host, port))
 
     counter = 0
     while True:


### PR DESCRIPTION
The `path.create()` can now take a boolean optional arg `parents`, which defaults to `False` (which is the original default from pathlib) and if set to `True` allows to create directory and parent directories directly in one call.